### PR TITLE
Fix:  README API startup inconsistency and typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	go tool cover -func=coverage.out -o=coverage.out
 	cat coverage.out
 
-docker-build-local: cross-compile
+docker-build: cross-compile
 	@echo "Building Local Docker image..."
 	@docker build -t fern-app . -f Dockerfile-local
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Fern is a Golang Gin-based API that connects to a PostgreSQL database. It is des
 2. **Start the API Server**: Navigate to the project directory and start the server.
    ```bash
    cd fern-reporter
-   make docker-run
+   make docker-run-local
    ```
 
 ### Integrating the Client into Ginkgo Test Suites


### PR DESCRIPTION
Corrected README API startup instructions to match Makefile definitions. Fixed typo in Makefile: docker-run-local now correctly calls docker-build.