### PR TITLE
Fix: Modify the static header to be dynamically set

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 type config struct {
 	Db     *dbConfig
 	Server *serverConfig
+	Header string
 }
 
 type dbConfig struct {
@@ -69,6 +70,9 @@ func LoadConfig() (*config, error) {
 	if os.Getenv("FERN_DATABASE") != "" {
 		configuration.Db.Database = os.Getenv("FERN_DATABASE")
 	}
+	if os.Getenv("FERN_HEADER_NAME") != "" {
+		configuration.Header = os.Getenv("FERN_HEADER_NAME")
+	}
 
 	return configuration, nil
 }
@@ -79,4 +83,8 @@ func GetDb() *dbConfig {
 
 func GetServer() *serverConfig {
 	return configuration.Server
+}
+
+func GetHeaderName() string {
+	return configuration.Header
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,3 +10,4 @@ db:
   max-idle-conns: 10
 server:
   port: :8080
+header: "Fern Acceptance Test Report"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,7 @@ var _ = Describe("When LoadConfig is invoked", func() {
 			Expect(appConfig.Db.DetailLog).To(BeTrue())
 			Expect(appConfig.Db.MaxOpenConns).To(Equal(100))
 			Expect(appConfig.Db.MaxIdleConns).To(Equal(10))
+			Expect(appConfig.Header).To(Equal("Fern Acceptance Test Report"))
 		})
 
 		It("should get non-nil DB", func() {
@@ -63,6 +64,7 @@ var _ = Describe("When LoadConfig is invoked", func() {
 		os.Setenv("FERN_HOST", "localhost")
 		os.Setenv("FERN_PORT", "5432")
 		os.Setenv("FERN_DATABASE", "fern")
+		os.Setenv("FERN_HEADER_NAME", "Custom Fern Report Header")
 
 		//v := viper.New()
 		result, err := config.LoadConfig()
@@ -74,6 +76,7 @@ var _ = Describe("When LoadConfig is invoked", func() {
 		Expect(result.Db.Host).To(Equal("localhost"))
 		Expect(result.Db.Port).To(Equal("5432"))
 		Expect(result.Db.Database).To(Equal("fern"))
+		Expect(result.Header).To(Equal("Custom Fern Report Header"))
 	})
 
 })

--- a/pkg/api/handlers/handlers.go
+++ b/pkg/api/handlers/handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"github.com/guidewire/fern-reporter/config"
 	"log"
 	"net/http"
 	"strconv"
@@ -149,7 +150,8 @@ func (h *Handler) ReportTestRunAll(c *gin.Context) {
 	var testRuns []models.TestRun
 	h.db.Preload("SuiteRuns.SpecRuns.Tags").Find(&testRuns)
 	c.HTML(http.StatusOK, "test_runs.html", gin.H{
-		"testRuns": testRuns,
+		"reportHeader": config.GetHeaderName(),
+		"testRuns":     testRuns,
 	})
 }
 
@@ -158,7 +160,8 @@ func (h *Handler) ReportTestRunById(c *gin.Context) {
 	id := c.Param("id")
 	h.db.Preload("SuiteRuns.SpecRuns").Where("id = ?", id).First(&testRun)
 	c.HTML(http.StatusOK, "test_runs.html", gin.H{
-		"testRuns": []models.TestRun{testRun},
+		"reportHeader": config.GetHeaderName(),
+		"testRuns":     []models.TestRun{testRun},
 	})
 }
 

--- a/pkg/views/test_runs.html
+++ b/pkg/views/test_runs.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ATMOS Acceptance Tests</title>
+    <title>{{ .reportHeader }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
     <style>
       body {
@@ -66,7 +66,7 @@
   </head>
   <body>
     <div class="container">
-      <h1 class="title is-3 has-text-centered has-background-primary has-text-white p-4">ATMOS Acceptance Tests</h1>
+      <h1 class="title is-3 has-text-centered has-background-primary has-text-white p-4">{{ .reportHeader }}</h1>
       <div>
         <table style="width: 100%;">
           <tr>


### PR DESCRIPTION
The header displayed in the Fern Reporter is now set through the environment variable `FERN_HEADER_NAME`. If the variable is not set, the header name defaults to `Fern Acceptance Test Report`.