### PR TITLE
Feat: Add JSON and HTML apis for reports/testruns

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,27 @@ Fern is a Golang Gin-based API that connects to a PostgreSQL database. It is des
 
 ### Integrating the Client into Ginkgo Test Suites
 
-  Refer the client repository to integrate the client to Ginkgo Test Suites: 
+* Refer the client repository to integrate the client to Ginkgo Test Suites: 
   https://github.com/Guidewire/fern-ginkgo-client
+* After adding the client, run your Ginkgo tests normally.
 
-2. **Run Your Tests**: After adding the client, run your Ginkgo tests normally.
+### Accessing Test Reports using embedded HTML view
 
-### Accessing Test Reports
+- View reports at `http://[your-api-url]/reports/testruns/`.
+- If using `make docker-run-local`, reports are available at `http://localhost:8080/reports/testruns/`.
+
+### Accessing Test Reports using Fern-UI
+
+To view the test reports using the React-based Fern-UI frontend, follow these steps:
+
+- Follow the instructions in the [Fern-UI repository](https://github.com/Guidewire/fern-ui) to set up and run the frontend application.
+- Once the Fern-UI is running, access the dashboard at `http://[frontend-api-url]/testruns` to view the test reports.
 
 - View reports at `http://[your-api-url]/reports/testruns`.
 - If using `make docker-run-local`, reports are available at `http://localhost:8080/reports/testruns`.
+
+### Accessing Test Reports using the API
+Reports are also available as JSON at `http://[host-url]/api/reports/testruns`.
 
 ### Additional Resources
 

--- a/pkg/api/handlers/handlers.go
+++ b/pkg/api/handlers/handlers.go
@@ -148,13 +148,35 @@ func (h *Handler) DeleteTestRun(c *gin.Context) {
 func (h *Handler) ReportTestRunAll(c *gin.Context) {
 	var testRuns []models.TestRun
 	h.db.Preload("SuiteRuns.SpecRuns.Tags").Find(&testRuns)
+
+	c.JSON(http.StatusOK, gin.H{
+		"testRuns":     testRuns,
+		"reportHeader": config.GetHeaderName(),
+		"total":        len(testRuns),
+	})
+}
+
+func (h *Handler) ReportTestRunById(c *gin.Context) {
+	var testRun models.TestRun
+	id := c.Param("id")
+	h.db.Preload("SuiteRuns.SpecRuns").Where("id = ?", id).First(&testRun)
+
+	c.JSON(http.StatusOK, gin.H{
+		"reportHeader": config.GetHeaderName(),
+		"testRuns":     []models.TestRun{testRun},
+	})
+}
+
+func (h *Handler) ReportTestRunAllHTML(c *gin.Context) {
+	var testRuns []models.TestRun
+	h.db.Preload("SuiteRuns.SpecRuns.Tags").Find(&testRuns)
 	c.HTML(http.StatusOK, "test_runs.html", gin.H{
 		"reportHeader": config.GetHeaderName(),
 		"testRuns":     testRuns,
 	})
 }
 
-func (h *Handler) ReportTestRunById(c *gin.Context) {
+func (h *Handler) ReportTestRunByIdHTML(c *gin.Context) {
 	var testRun models.TestRun
 	id := c.Param("id")
 	h.db.Preload("SuiteRuns.SpecRuns").Where("id = ?", id).First(&testRun)

--- a/pkg/api/routers/routers.go
+++ b/pkg/api/routers/routers.go
@@ -33,6 +33,10 @@ func RegisterRouters(router *gin.Engine) {
 		testRun.POST("/", handler.CreateTestRun)
 		testRun.PUT("/:id", handler.UpdateTestRun)
 		testRun.DELETE("/:id", handler.DeleteTestRun)
+
+		testReport := api.Group("/reports/testruns")
+		testReport.GET("/", handler.ReportTestRunAll)
+		testReport.GET("/:id", handler.ReportTestRunById)
 	}
 
 	var reports *gin.RouterGroup
@@ -44,8 +48,8 @@ func RegisterRouters(router *gin.Engine) {
 
 	reports.Use()
 	{
-		testRunReport := reports.GET("/", handler.ReportTestRunAll)
-		testRunReport.GET("/:id", handler.ReportTestRunById)
+		reports.GET("/", handler.ReportTestRunAllHTML)
+		reports.GET("/:id", handler.ReportTestRunByIdHTML)
 	}
 
 	var ping *gin.RouterGroup


### PR DESCRIPTION
1. Render ReportTestRunAll data as json instead of HTML.
2. Update README for accessing the Fern-UI dashboard for test results.