### PR TITLE
Refactor: updates wrong command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Fern is a Golang Gin-based API that connects to a PostgreSQL database. It is des
 ### Accessing Test Reports
 
 - View reports at `http://[your-api-url]/reports/testruns`.
-- If using `make docker-run`, reports are available at `http://localhost:8080/reports/testruns`.
+- If using `make docker-run-local`, reports are available at `http://localhost:8080/reports/testruns`.
 
 ### Additional Resources
 


### PR DESCRIPTION
Readme says `make docker-run` while the original command to run locally is `make docker-run-local`. Changed it.